### PR TITLE
Api routes crud

### DIFF
--- a/src/app/api/admin/categories/[categoryId]/route.ts
+++ b/src/app/api/admin/categories/[categoryId]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest,NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import dbConnect from "@/lib/dbConnect";
+import Category from "@/models/Category";
+import Submission from "@/models/Submission";
+
+export async function DELETE(request : NextRequest,{params}:{params : {categoryId : string}}){
+  try {
+    const session=await getServerSession(authOptions);
+    if(!session?.user || session.user.role !=='admin'){
+      return NextResponse.json(
+        {error : "Unauthorized"},
+        {status:401}
+      );
+    }
+
+    await dbConnect();
+
+    const deletedCategory= await Category.findByIdAndDelete(params.categoryId)
+    if(!deletedCategory){
+      return NextResponse.json(
+        {error: "Category not found"},
+        {status:404}
+      );
+    }
+
+    await Submission.deleteMany({category : params.categoryId})
+
+    return NextResponse.json(
+      {message:"Category Deleted Suuccessfully"},
+      {status : 200}
+    );
+
+
+  } catch (error) {
+    console.log(`ERROR :: ADMIN CATEGORY DELETION :: ${error}`);
+    return NextResponse.json(
+      {error : "Internal Server Error "},
+      {status : 500}
+    );
+  }
+}

--- a/src/app/api/admin/users/[userId[/route.ts
+++ b/src/app/api/admin/users/[userId[/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest,NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import dbConnect from "@/lib/dbConnect";
+import User from "@/models/User";
+import Category from "@/models/Category";
+import Submission from "@/models/Submission";
+
+
+export async function DELETE( request : NextRequest , {params}:{params :{userId : string}}){
+  try {
+    const session=await getServerSession(authOptions);
+    if(!session?.user || session.user.role !=='admin'){
+      return NextResponse.json(
+        {error:"Unauthorized"},
+        {status : 401}
+      );
+    }
+
+    await dbConnect();
+
+    const user=await User.findByIdAndDelete(params.userId);
+    if(!user){
+      return NextResponse.json(
+        {error : "User not found"},
+        {status:404}
+      );
+    }
+
+    if(user.role==='teacher'){
+      const categories=await Category.find({teacher:user._id});
+      const categoryIds= categories.map(c=>c._id);
+      await Submission.deleteMany({category : { $in : categoryIds}});
+      await Category.deleteMany({teacher : user._id});
+    }
+    else if(user.role ==='student'){
+      await Submission.deleteMany({student : user._id});
+    }
+
+    return NextResponse.json(
+      {message : "User deleted Suuccessfully"},
+      {status:200}
+    );
+  } catch (error) {
+    console.log(`ERROR :: ADMIN USER DELETION :: ${error}`);
+    return  NextResponse.json(
+      {error : "Internal Server Error "},
+      {status : 500}
+    );
+  }
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,6 +5,28 @@ import User from "@/models/User";
 import { compare } from "bcrypt";
 import formSchema from "@/lib/schemas/signin";
 
+//ADDING CUSTOM FIELDS TO DEFAULT TYPES PROVIDED BY NEXT-AUTH
+declare module "next-auth"{
+  interface User{
+    id:string;
+    role:string;
+  }
+
+  interface Session{
+    user:User;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT{
+    id:string;
+    role:string;
+  }
+}
+
+
+
+
 export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
@@ -21,7 +43,13 @@ export const authOptions: NextAuthOptions = {
           if (user && password) {
             if (await compare(password, user.password)) {
               console.log({ ...user, id: user._id.toString() });
-              return { ...user, id: user._id.toString() };
+              // return { ...user, id: user._id.toString() };
+              return {
+                id: user._id.toString(),
+                email:user.email,
+                role : user.role,
+                name: user.name
+              };
             }
           }
           return null;
@@ -38,13 +66,17 @@ export const authOptions: NextAuthOptions = {
   },
   callbacks: {
     async jwt({ token, user }) {
-      if (user) token.id = user.id;
-      console.log("TOKEN:", token);
+      if (user) {
+        token.id = user.id;
+        token.role=user.role;
+        console.log("TOKEN:", token);
+      }
       return token;
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async session({ session, token }: any) {
       session.user.id = token.id;
+      session.user.role = token.role;
       return session;
     },
   },

--- a/src/app/api/categories/[categoryId]/route.ts
+++ b/src/app/api/categories/[categoryId]/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest,NextResponse } from "next/server";
+import { categoryValidationSchema } from "@/lib/schemas/categoryCreation";
+import dbConnect from "@/lib/dbConnect";
+import Category from "@/models/Category";
+import Submission from "@/models/Submission";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../../auth/[...nextauth]/route";
+
+
+
+export async function PUT(request : NextRequest,{params} : {params : {categoryId : string}}){
+  try {
+    const session = await getServerSession(authOptions)
+    if(!session?.user){
+      return NextResponse.json(
+        {error : 'Unauthorized'},
+        {status : 401}
+      );
+    }
+
+    const body=await request.json();
+    const validation = categoryValidationSchema.safeParse(body);
+
+    if(!validation.success){
+      return NextResponse.json(
+        {error : validation.error.flatten().fieldErrors},
+        {status:400}
+      );
+    }
+
+    await dbConnect();
+
+    const category = await Category.findById(params.categoryId);
+    if(!category){
+      return NextResponse.json(
+        {error : 'Category not found'},
+        {status : 404}
+      );
+    }
+
+    if(session.user.role ==='student'){
+      return NextResponse.json(
+        {error:'Forbidden . Only teachers and admins can perform this action.'},
+        {status:403}
+      );
+    }
+
+    if(session.user.role==='teacher' && category.teacher.toString()!==session.user.id){
+      return NextResponse.json(
+        {error : 'Forbidden . Teachers can only modify their own categories.'},
+        {status:403}
+      );
+    }
+
+    const updatedCategory=await Category.findByIdAndUpdate(
+      params.categoryId,
+      {
+        ...validation.data,
+        deadline: new Date(validation.data.deadline)
+      },
+      {new : true , runValidators:true}
+    );
+
+    return NextResponse.json(
+      {message: 'Category updated', category: updatedCategory},
+      {status:200}
+    );
+
+  } catch (error) {
+    console.log(`ERROR :: CATEGORY UPDATE ERROR :: ${error}`);
+    return NextResponse.json(
+      {error:'Internal Server error'},
+      {status:500}
+    );
+  }
+}
+
+export async function DELETE(request : NextRequest,{params} : {params : {categoryId : string}}){
+  try {
+    const session = await getServerSession(authOptions)
+    if(!session?.user){
+      return NextResponse.json(
+        {error : 'Unauthorized'},
+        {status : 401}
+      );
+    }
+
+    await dbConnect();
+
+    const category = await Category.findById(params.categoryId);
+    if(!category){
+      return NextResponse.json(
+        {error : 'Category not found'},
+        {status : 404}
+      );
+    }
+
+    if(session.user.role ==='student'){
+      return NextResponse.json(
+        {error:'Forbidden . Only teachers and admins can perform this action.'},
+        {status:403}
+      );
+    }
+
+    if(session.user.role==='teacher' && category.teacher.toString()!==session.user.id){
+      return NextResponse.json(
+        {error : 'Forbidden . Teachers can only delete their own categories.'},
+        {status:403}
+      );
+    }
+
+    const deletedCategory=await Category.findByIdAndDelete(params.categoryId);
+    if(!deletedCategory){
+      return NextResponse.json(
+        {error : 'Category not found'},
+        {status:404}
+      );
+    }
+
+    await Submission.deleteMany({category: params.categoryId});
+
+    return NextResponse.json(
+      {message: 'Category deleted'},
+      {status:200}
+    );
+
+  } catch (error) {
+    console.log(`ERROR :: CATEGORY DELETION ERROR :: ${error}`);
+    return NextResponse.json(
+      {error:'Internal Server error'},
+      {status:500}
+    );
+  }
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { categoryValidationSchema } from "@/lib/schemas/categoryCreation";
+import dbConnect from "@/lib/dbConnect";
+import Category from "@/models/Category";
+import { getServerSession } from "next-auth";
+import { authOptions } from "../auth/[...nextauth]/route";
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user || !['teacher', 'admin'].includes(session?.user.role)) {
+      return NextResponse.json({
+        error: "Unauthorized"
+      },
+        { status: 403 });
+    }
+
+    const body = await request.json();
+    const validation = categoryValidationSchema.safeParse(body);
+
+    if(!validation.success){
+      return NextResponse.json(
+        {error : validation.error.flatten().fieldErrors},
+        {status:400}
+      );
+    }
+
+    await dbConnect();
+
+    const newCategory=new Category({
+      ...validation.data,
+      teacher:session.user.id,
+      deadline : new Date(validation.data.deadline),
+      submissions:[]
+    });
+
+    await newCategory.save();
+
+    return NextResponse.json(
+      {message:"Category Created ", category : newCategory},
+      {status:201}
+    );
+
+  } catch (error) {
+    console.log(`ERROR :: CATEGORY CREATION ERROR :: ${error}`);
+    return NextResponse.json(
+      {error : 'Internal Server Error'},
+      {status : 500}
+    );
+    
+  }
+}

--- a/src/lib/schemas/categoryCreation.ts
+++ b/src/lib/schemas/categoryCreation.ts
@@ -1,0 +1,24 @@
+import {z} from 'zod';
+
+export const categoryValidationSchema=  z.object({
+  name:z.string()
+    .min(3,{message:"Name must be atleast 3 characters long"})
+    .max(50,{message:"Name cannot exceed 50 characters"}),
+  description:z.string()
+    .min(10,{message : "Description must be at least 10 characters long"})
+     .max(500,{message:"description cannot exceed 500 characters"}),
+  evaluationParameters: z.array(
+    z.string()
+      .min(2,{message : "Evaluation parameter must be atleast 2 characters"})
+      .max(30,{message : "Evaluation parameter cannot excedd 30 character"})
+    ).min(1,{message : "Atleast 1 evaluation parameter is required"})
+    .max(5,{message:"At most 5 evaluation parameters are required"}),
+
+    deadline : z.string()
+    .refine((date)=> new Date(date) > new Date(),{
+      message : "Deadline must be in the future"
+    })
+});
+
+export type CategoryFormValues= z.infer<typeof categoryValidationSchema>;
+

--- a/src/models/Category.ts
+++ b/src/models/Category.ts
@@ -2,6 +2,7 @@ import mongoose, { Document, Schema, Types } from "mongoose";
 
 interface Categories extends Document {
   name: string;
+  description:string;
   teacher: Types.ObjectId; //REFERENCE TO TEACHER
   submissions: Types.ObjectId[]; //REFERENCE TO SUBMSSIONS
   deadline: Date;
@@ -16,6 +17,10 @@ const categorySchema = new Schema<Categories>(
       type: String,
       required: [true, "Category missing"],
       trim: true,
+    },
+    description:{
+      type:String,
+      required:[true,"Description is required"]
     },
     teacher: {
       type: Schema.Types.ObjectId,

--- a/src/models/Submission.ts
+++ b/src/models/Submission.ts
@@ -4,6 +4,7 @@ import mongoose, { Document, Schema, Types } from "mongoose";
 
 interface Submissions extends Document {
   title: string;
+  description?:string;
   student: Types.ObjectId; //REFERENCE TO USER
   category: Types.ObjectId; //REFERENCE TO CATEGORY
   content: {
@@ -27,6 +28,9 @@ const submissionSchema = new Schema<Submissions>(
       type: String,
       required: [true, "Submission title missing"],
       trim: true,
+    },
+    description:{
+      type:String
     },
     student: {
       type: Schema.Types.ObjectId,


### PR DESCRIPTION
Updated **/api/auth/[...nextauth]/route.ts** to extend the default User type provided by NextAuth, now including the role attribute for session and JWT.

Added API routes for Teacher Category Management:
  |->Create, Update, and Delete categories.
    

Added API routes for Admin User & Category Management:
   |->Delete students, teachers, and categories.

Go through them once and let me know if there are any changes required 

